### PR TITLE
fix: APPLICATION_MODEL type doesn't exist upon the discord-interactions

### DIFF
--- a/examples/modal.js
+++ b/examples/modal.js
@@ -22,7 +22,7 @@ app.post('/interactions', function (req, res) {
     if (data.name === 'test') {
       // Send a modal as response
       return res.send({
-        type: InteractionResponseType.APPLICATION_MODAL,
+        type: InteractionResponseType.MODAL,
         data: {
           custom_id: 'my_modal',
           title: 'Modal title',


### PR DESCRIPTION
As of issue https://github.com/discord/discord-example-app/issues/21